### PR TITLE
Null replaceValue and multiLine findRegex processing.

### DIFF
--- a/src/main/java/io/github/floverfelt/find/and/replace/maven/plugin/FindAndReplaceMojo.java
+++ b/src/main/java/io/github/floverfelt/find/and/replace/maven/plugin/FindAndReplaceMojo.java
@@ -74,7 +74,7 @@ public class FindAndReplaceMojo extends AbstractMojo {
    *
    * @parameter replaceValue
    */
-  @Parameter(property = "replaceValue", required = true, defaultValue = "")
+  @Parameter(property = "replaceValue", defaultValue = "")
   private String replaceValue;
 
   /**

--- a/src/main/java/io/github/floverfelt/find/and/replace/maven/plugin/tasks/ProcessFilesTask.java
+++ b/src/main/java/io/github/floverfelt/find/and/replace/maven/plugin/tasks/ProcessFilesTask.java
@@ -2,11 +2,7 @@ package io.github.floverfelt.find.and.replace.maven.plugin.tasks;
 
 import org.apache.maven.plugin.logging.Log;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
+import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -168,6 +164,10 @@ public class ProcessFilesTask {
       }
     }
 
+    if(!applyAccessBits(file, tempFile)){
+      throw new RuntimeException("Failed to apply access bits at: " + file.getPath());
+    }
+
     if (!file.delete()) {
       throw new IOException("Failed to delete file at: " + file.getPath());
     }
@@ -196,4 +196,11 @@ public class ProcessFilesTask {
 
   }
 
+  private static boolean applyAccessBits(File original, File successor){
+    String actions = new FilePermission(original.getPath(), "read, write, execute").getActions();
+    return
+            successor.setReadable(actions.contains("read"))
+            && successor.setWritable(actions.contains("write"))
+            && successor.setExecutable(actions.contains("execute"));
+  }
 }

--- a/src/test/java/io/github/floverfelt/find/and/replace/maven/plugin/FindAndReplaceMojoTest.java
+++ b/src/test/java/io/github/floverfelt/find/and/replace/maven/plugin/FindAndReplaceMojoTest.java
@@ -476,7 +476,7 @@ public class FindAndReplaceMojoTest {
   public void testFileContentsMultiLineRegex() throws IOException, NoSuchFieldException, IllegalAccessException,
           MojoExecutionException, MojoFailureException {
 
-    setFieldValue(findAndReplaceMojo, "findRegex", "asdf\r\n\r\n-test-");
+    setFieldValue(findAndReplaceMojo, "findRegex", "asdf" + System.lineSeparator() + System.lineSeparator() + "-test-");
     String replaceValue = "value successfully replaced";
     setFieldValue(findAndReplaceMojo, "replaceValue", replaceValue);
     setFieldValue(findAndReplaceMojo, "processFileContents", true);
@@ -494,11 +494,12 @@ public class FindAndReplaceMojoTest {
     assertTrue(fileContains(ymlTestFile.toFile(), "asdf"));
 
   }
+  
   @Test
   public void testFileContentsMultiLineRegex2() throws IOException, NoSuchFieldException, IllegalAccessException,
           MojoExecutionException, MojoFailureException {
 
-    setFieldValue(findAndReplaceMojo, "findRegex", "asdf[\\w\\W]{4,37}-test-");
+    setFieldValue(findAndReplaceMojo, "findRegex", "asdf[\\w\\W]{2,37}-test-");
     String replaceValue = "value successfully replaced";
     setFieldValue(findAndReplaceMojo, "replaceValue", replaceValue);
     setFieldValue(findAndReplaceMojo, "processFileContents", true);
@@ -522,7 +523,7 @@ public class FindAndReplaceMojoTest {
   public void testFileContentsRegexN() throws NoSuchFieldException, IllegalAccessException,
           MojoExecutionException, MojoFailureException {
 
-    String regex = "\\n";
+    String regex = System.lineSeparator();
     setFieldValue(findAndReplaceMojo, "findRegex", regex);
     String replaceValue = "";
     setFieldValue(findAndReplaceMojo, "exclusions", ".yml$");
@@ -543,6 +544,40 @@ public class FindAndReplaceMojoTest {
     assertTrue(regexFileContains(xmlTestFile.toFile(), "-test-"));
     assertTrue(regexFileContains(ymlTestFile.toFile(), "asdf"));
 
+  }
+  
+  @Test
+  public void testFilePosixPermissionPositive() throws NoSuchFieldException, IllegalAccessException, MojoExecutionException, MojoFailureException{
+      textTestFile.toFile().setExecutable(true);
+      String regex = System.lineSeparator();
+      setFieldValue(findAndReplaceMojo, "findRegex", regex);
+      String replaceValue = "";
+      setFieldValue(findAndReplaceMojo, "exclusions", "^(\\.txt$)");
+      setFieldValue(findAndReplaceMojo, "replaceValue", replaceValue);
+      setFieldValue(findAndReplaceMojo, "processFileContents", true);
+      setFieldValue(findAndReplaceMojo, "replacementType", "file-contents");
+      setFieldValue(findAndReplaceMojo, "replaceAll", true);
+      
+      findAndReplaceMojo.execute();
+            
+      assertTrue(textTestFile.toFile().canExecute());
+  }
+  
+  @Test
+  public void testFilePosixPermissionNegative() throws NoSuchFieldException, IllegalAccessException, MojoExecutionException, MojoFailureException{
+      textTestFile.toFile().setExecutable(false);
+      String regex = System.lineSeparator();
+      setFieldValue(findAndReplaceMojo, "findRegex", regex);
+      String replaceValue = "";
+      setFieldValue(findAndReplaceMojo, "exclusions", "^(\\.txt$)");
+      setFieldValue(findAndReplaceMojo, "replaceValue", replaceValue);
+      setFieldValue(findAndReplaceMojo, "processFileContents", true);
+      setFieldValue(findAndReplaceMojo, "replacementType", "file-contents");
+      setFieldValue(findAndReplaceMojo, "replaceAll", true);
+      
+      findAndReplaceMojo.execute();
+            
+      assertFalse(textTestFile.toFile().canExecute());
   }
 
   @Test

--- a/src/test/java/io/github/floverfelt/find/and/replace/maven/plugin/FindAndReplaceMojoTest.java
+++ b/src/test/java/io/github/floverfelt/find/and/replace/maven/plugin/FindAndReplaceMojoTest.java
@@ -1151,7 +1151,7 @@ public class FindAndReplaceMojoTest {
 
       Stream<String> lines = fileReader.lines();
 
-      return lines.anyMatch(line -> line.contains(findValue) || line.matches(findValue));
+      return lines.anyMatch(line -> line.contains(findValue));
     }
   }
 

--- a/src/test/java/io/github/floverfelt/find/and/replace/maven/plugin/FindAndReplaceMojoTest.java
+++ b/src/test/java/io/github/floverfelt/find/and/replace/maven/plugin/FindAndReplaceMojoTest.java
@@ -4,9 +4,11 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.MethodSorters;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -34,6 +36,7 @@ import static junit.framework.TestCase.assertTrue;
  * They dynamically generate the folders/files, and then check that the plugin is working as expected.
  */
 @RunWith(BlockJUnit4ClassRunner.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class FindAndReplaceMojoTest {
 
   private final FindAndReplaceMojo findAndReplaceMojo = new FindAndReplaceMojo();
@@ -234,7 +237,7 @@ public class FindAndReplaceMojoTest {
           MojoExecutionException, MojoFailureException {
 
     Path firstDir = Files.createDirectory(Paths.get(runningTestsPath.toString(), "test-directory"));
-    Files.createFile(Paths.get(runningTestsPath.toString(), "some_file_name")).toUri();
+    Files.createFile(Paths.get(runningTestsPath.toString(), "some_file_name"));
     Path nonRecurseFile = Files.createFile(Paths.get(firstDir.toString(), "some_file_name"));
 
     setFieldValue(findAndReplaceMojo, "findRegex", "_");
@@ -255,7 +258,7 @@ public class FindAndReplaceMojoTest {
           MojoExecutionException, MojoFailureException {
 
     Path firstDir = Files.createDirectory(Paths.get(runningTestsPath.toString(), "test-directory"));
-    Files.createFile(Paths.get(runningTestsPath.toString(), "some_file_name")).toUri();
+    Files.createFile(Paths.get(runningTestsPath.toString(), "some_file_name"));
     Path nonRecurseFile = Files.createFile(Paths.get(firstDir.toString(), "some_file_name"));
 
     setFieldValue(findAndReplaceMojo, "findRegex", "_");
@@ -276,7 +279,7 @@ public class FindAndReplaceMojoTest {
           MojoExecutionException, MojoFailureException {
 
     Path firstDir = Files.createDirectory(Paths.get(runningTestsPath.toString(), "test-directory"));
-    Files.createFile(Paths.get(runningTestsPath.toString(), "some_file_name")).toUri();
+    Files.createFile(Paths.get(runningTestsPath.toString(), "some_file_name"));
     Files.createFile(Paths.get(firstDir.toString(), "some_file_name"));
 
     setFieldValue(findAndReplaceMojo, "findRegex", "_");
@@ -298,7 +301,7 @@ public class FindAndReplaceMojoTest {
           MojoExecutionException, MojoFailureException {
 
     Path firstDir = Files.createDirectory(Paths.get(runningTestsPath.toString(), "test-directory"));
-    Files.createFile(Paths.get(runningTestsPath.toString(), "some_file_name")).toUri();
+    Files.createFile(Paths.get(runningTestsPath.toString(), "some_file_name"));
     Files.createFile(Paths.get(firstDir.toString(), "some_file_name"));
 
     setFieldValue(findAndReplaceMojo, "findRegex", "_");
@@ -469,6 +472,52 @@ public class FindAndReplaceMojoTest {
     assertFalse(fileContains(textTestFile.toFile(), "asdf"));
     assertFalse(fileContains(xmlTestFile.toFile(), "asdf"));
     assertFalse(fileContains(ymlTestFile.toFile(), "asdf"));
+
+  }
+
+  @Test
+  public void testFileContentsMultiLineRegex() throws IOException, NoSuchFieldException, IllegalAccessException,
+          MojoExecutionException, MojoFailureException {
+
+    setFieldValue(findAndReplaceMojo, "findRegex", "asdf\r\n\r\n-test-");
+    String replaceValue = "value successfully replaced";
+    setFieldValue(findAndReplaceMojo, "replaceValue", replaceValue);
+    setFieldValue(findAndReplaceMojo, "processFileContents", true);
+    setFieldValue(findAndReplaceMojo, "replacementType", "file-contents");
+    setFieldValue(findAndReplaceMojo, "replaceAll", true);
+
+    findAndReplaceMojo.execute();
+
+    assertTrue(fileContains(textTestFile.toFile(), replaceValue));
+    assertFalse(fileContains(xmlTestFile.toFile(), replaceValue));
+    assertFalse(fileContains(ymlTestFile.toFile(), replaceValue));
+
+    assertTrue(fileContains(textTestFile.toFile(), "asdf"));
+    assertTrue(fileContains(xmlTestFile.toFile(), "asdf"));
+    assertTrue(fileContains(ymlTestFile.toFile(), "asdf"));
+
+  }
+  @Test
+  public void testFileContentsMultiLineRegex2() throws IOException, NoSuchFieldException, IllegalAccessException,
+          MojoExecutionException, MojoFailureException {
+
+    setFieldValue(findAndReplaceMojo, "findRegex", "asdf[\\w\\W]{4,37}-test-");
+    String replaceValue = "value successfully replaced";
+    setFieldValue(findAndReplaceMojo, "replaceValue", replaceValue);
+    setFieldValue(findAndReplaceMojo, "processFileContents", true);
+    setFieldValue(findAndReplaceMojo, "replacementType", "file-contents");
+    setFieldValue(findAndReplaceMojo, "replaceAll", true);
+
+    findAndReplaceMojo.execute();
+
+    assertTrue(fileContains(textTestFile.toFile(), replaceValue));
+    assertTrue(fileContains(xmlTestFile.toFile(), replaceValue));
+    assertFalse(fileContains(ymlTestFile.toFile(), replaceValue));
+
+    assertTrue(fileContains(textTestFile.toFile(), "asdf"));
+    assertTrue(fileContains(xmlTestFile.toFile(), "asdf"));
+    assertTrue(fileContains(xmlTestFile.toFile(), "-test-"));
+    assertTrue(fileContains(ymlTestFile.toFile(), "asdf"));
 
   }
 


### PR DESCRIPTION
Removed "required" attribute of "replaceValue" parameter.

Empty String replacement for null "replaceValue" parameter added at ProcessFilesTask.processFileContents.

ProcessFilesTask.processFileContents method was modified to achieve multiline findRegex processing.

Corresponding tests were added:
* FindAndReplaceMojoTest.testFileContentsMultiLineRegex
* FindAndReplaceMojoTest.testFileContentsMultiLineRegex2

Removed redundant toUri() calls at several tests.