### PR TITLE
feat: skipOnMissingBaseDir

### DIFF
--- a/src/main/java/io/github/floverfelt/find/and/replace/maven/plugin/FindAndReplaceMojo.java
+++ b/src/main/java/io/github/floverfelt/find/and/replace/maven/plugin/FindAndReplaceMojo.java
@@ -37,6 +37,14 @@ public class FindAndReplaceMojo extends AbstractMojo {
   private String baseDir;
 
   /**
+   * Skips the processing if the base dir does not exist without an error.
+   *
+   * @parameter skipOnMissingBaseDir
+   */
+  @Parameter(property = "skipOnMissingBaseDir", defaultValue = "false")
+  private boolean skipOnMissingBaseDir;
+
+  /**
    * Whether the find and replace is recursive from the baseDir.
    *
    * @parameter recursive
@@ -153,7 +161,7 @@ public class FindAndReplaceMojo extends AbstractMojo {
     getLog().info("Executing find-and-replace maven plugin with options: " + this.toString());
 
     try {
-      ProcessFilesTask.process(getLog(), baseDirPath, recursive, Pattern.compile(findRegex), replaceValue, fileMaskList,
+      ProcessFilesTask.process(getLog(), baseDirPath, skipOnMissingBaseDir, recursive, Pattern.compile(findRegex), replaceValue, fileMaskList,
           exclusionsList, processFileContents, processFilenames, processDirectoryNames, replaceAll, charset);
     } catch (Exception e) {
       throw new MojoFailureException("Unable to process files.", e);
@@ -256,6 +264,7 @@ public class FindAndReplaceMojo extends AbstractMojo {
   public String toString() {
     final StringBuilder sb = new StringBuilder("FindAndReplaceMojo{");
     sb.append("baseDir='").append(baseDir).append('\'');
+    sb.append(", skipOnMissingBaseDir='").append(skipOnMissingBaseDir).append('\'');
     sb.append(", recursive=").append(recursive);
     sb.append(", replacementType='").append(replacementType).append('\'');
     sb.append(", findRegex='").append(findRegex).append('\'');

--- a/src/main/java/io/github/floverfelt/find/and/replace/maven/plugin/tasks/ProcessFilesTask.java
+++ b/src/main/java/io/github/floverfelt/find/and/replace/maven/plugin/tasks/ProcessFilesTask.java
@@ -32,6 +32,7 @@ public class ProcessFilesTask {
    *
    * @param log                   the maven-plugin log
    * @param baseDir               the directory to start in
+   * @param skipOnMissingBaseDir  skips the processing of a missing baseDir without any errors
    * @param isRecursive           whether to recurse further
    * @param findRegex             the regex to find
    * @param replaceValue          the value to replace the found regex
@@ -42,13 +43,18 @@ public class ProcessFilesTask {
    * @param processDirectoryNames whether to process directory names
    * @param charset               encoding to be used when reading files
    */
-  public static void process(Log log, Path baseDir, boolean isRecursive, Pattern findRegex, String replaceValue,
+  public static void process(Log log, Path baseDir, boolean skipOnMissingBaseDir, boolean isRecursive, Pattern findRegex, String replaceValue,
                              List<String> fileMasks, List<Pattern> exclusions, boolean processFileContents,
                              boolean processFilenames, boolean processDirectoryNames, boolean replaceAll, Charset charset) throws IOException {
 
     // Load in the files in the base dir
     File[] baseDirFiles = new File(baseDir.toUri()).listFiles();
     if (baseDirFiles == null) {
+      // Skips the processing of a missing baseDir without any errors
+      if(skipOnMissingBaseDir) {
+        log.info(String.format("Skip the processing of baseDir='%s' as skipOnMissingBaseDir is set to 'true'.", baseDir));
+        return;
+      }
       throw new IOException(String.format("Unable to list file(s) in baseDir='%s'", baseDir));
     }
     List<File> filesToProcess = new ArrayList<>(Arrays.asList(baseDirFiles));


### PR DESCRIPTION
Allows to skip the processing of a missing baseDir without any errors